### PR TITLE
fix: harden FFI plugin event delivery against race conditions

### DIFF
--- a/components/host-sdk/src/proxies/change_receiver.rs
+++ b/components/host-sdk/src/proxies/change_receiver.rs
@@ -41,6 +41,20 @@ struct PushCallbackContext {
 /// The push callback invoked by the plugin forwarder for each event.
 /// Uses `std::sync::mpsc` which is safe to call from any runtime.
 extern "C" fn change_push_callback(ctx: *mut std::ffi::c_void, event: *mut FfiSourceEvent) -> bool {
+    // Catch panics to prevent unwinding across the extern "C" boundary (which is UB).
+    // On panic, return false to signal shutdown. The leaked Arc is NOT reclaimed here
+    // because we cannot know which code path panicked. It will be reclaimed when the
+    // forwarder task exits (via the null-event callback or send failure).
+    std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        change_push_callback_inner(ctx, event)
+    }))
+    .unwrap_or(false)
+}
+
+fn change_push_callback_inner(
+    ctx: *mut std::ffi::c_void,
+    event: *mut FfiSourceEvent,
+) -> bool {
     let context = unsafe { &*(ctx as *const PushCallbackContext) };
 
     if event.is_null() {
@@ -187,6 +201,17 @@ extern "C" fn bootstrap_push_callback(
     ctx: *mut std::ffi::c_void,
     event: *mut drasi_plugin_sdk::ffi::FfiBootstrapEvent,
 ) -> bool {
+    // Catch panics to prevent unwinding across the extern "C" boundary.
+    std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        bootstrap_push_callback_inner(ctx, event)
+    }))
+    .unwrap_or(false)
+}
+
+fn bootstrap_push_callback_inner(
+    ctx: *mut std::ffi::c_void,
+    event: *mut drasi_plugin_sdk::ffi::FfiBootstrapEvent,
+) -> bool {
     let context = unsafe { &*(ctx as *const BootstrapPushCallbackContext) };
 
     if event.is_null() {
@@ -243,7 +268,11 @@ unsafe impl Sync for FfiBootstrapReceiverState {}
 
 impl Drop for FfiBootstrapReceiverState {
     fn drop(&mut self) {
-        (self.drop_fn)(self.state);
+        // Run plugin drop on a dedicated thread to avoid initializing
+        // plugin TLS on the caller's thread (matches FfiReceiverState::drop).
+        let drop_fn = self.drop_fn;
+        let state = drasi_plugin_sdk::ffi::SendMutPtr(self.state);
+        let _ = std::thread::spawn(move || (drop_fn)(state.as_ptr())).join();
     }
 }
 

--- a/components/host-sdk/tests/integration_test.rs
+++ b/components/host-sdk/tests/integration_test.rs
@@ -2355,3 +2355,110 @@ async fn test_cdylib_source_dispatches_events() {
     drop(plugin);
     drop(_event_rx);
 }
+
+// ============================================================================
+// Stress test: rapid subscribe/drop with concurrent event delivery
+// ============================================================================
+
+/// Stress test targeting timing-dependent FFI race conditions.
+///
+/// Rapidly creates subscriptions, receives a few events, then drops the
+/// receiver while the plugin forwarder may still be pushing events. Repeats
+/// many times to exercise shutdown/cleanup timing windows.
+#[tokio::test]
+#[serial]
+async fn test_stress_rapid_subscribe_drop_under_load() {
+    if !plugin_exists("drasi-source-mock") {
+        eprintln!("SKIPPING: cdylib mock source plugin not found");
+        panic!("SKIPPING: cdylib mock source plugin not found");
+    }
+
+    let mock_source_path = require_plugin("drasi-source-mock");
+    let plugin = load_plugin_from_path(
+        &mock_source_path,
+        std::ptr::null_mut(),
+        callbacks::default_log_callback_fn(),
+        std::ptr::null_mut(),
+        callbacks::default_lifecycle_callback_fn(),
+    )
+    .expect("Should load mock source plugin");
+
+    // Fast timer (50ms) to maximize event throughput during stress test
+    let source_config = serde_json::json!({
+        "dataType": { "type": "counter" },
+        "intervalMs": 50
+    });
+    let source = plugin.source_plugins[0]
+        .create_source("stress-test", &source_config, false)
+        .await
+        .expect("Should create mock source");
+
+    let (event_tx, _event_rx) =
+        tokio::sync::mpsc::channel::<drasi_lib::component_graph::ComponentUpdate>(100);
+    let context = drasi_lib::context::SourceRuntimeContext::new(
+        "test-instance",
+        "stress-test",
+        None,
+        event_tx,
+        None,
+    );
+    source.initialize(context).await;
+    source.start().await.expect("Should start source");
+
+    // Wait for the source to be emitting events
+    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+
+    let iterations = 20;
+    for i in 0..iterations {
+        let settings = drasi_lib::config::SourceSubscriptionSettings {
+            source_id: "stress-test".to_string(),
+            enable_bootstrap: false,
+            query_id: format!("stress-query-{i}"),
+            nodes: std::collections::HashSet::new(),
+            relations: std::collections::HashSet::new(),
+        };
+        let sub = source.subscribe(settings).await.expect("Should subscribe");
+        let mut receiver = sub.receiver;
+
+        // Vary the timing: sometimes drop immediately, sometimes after
+        // receiving a few events, sometimes mid-event
+        match i % 4 {
+            0 => {
+                // Drop immediately — forwarder may not have started yet
+                drop(receiver);
+            }
+            1 => {
+                // Receive one event then drop
+                let _ = tokio::time::timeout(
+                    std::time::Duration::from_millis(200),
+                    receiver.recv(),
+                )
+                .await;
+                drop(receiver);
+            }
+            2 => {
+                // Receive several events then drop
+                for _ in 0..3 {
+                    let _ = tokio::time::timeout(
+                        std::time::Duration::from_millis(200),
+                        receiver.recv(),
+                    )
+                    .await;
+                }
+                drop(receiver);
+            }
+            _ => {
+                // Short sleep (overlapping with timer tick) then drop
+                tokio::time::sleep(std::time::Duration::from_millis(30)).await;
+                drop(receiver);
+            }
+        }
+
+        // Brief yield to let forwarder cleanup tasks run
+        tokio::task::yield_now().await;
+    }
+
+    // If we get here without crashing, the shutdown/cleanup paths are sound
+    source.stop().await.expect("Should stop source");
+    println!("Stress test completed: {iterations} rapid subscribe/drop cycles without crash");
+}

--- a/components/plugin-sdk/src/ffi/vtable_gen.rs
+++ b/components/plugin-sdk/src/ffi/vtable_gen.rs
@@ -2065,9 +2065,15 @@ fn wrap_subscription_response(
         let rt_handle = receiver.runtime_handle.clone();
         rt_handle.spawn(async move {
             let mut rx = receiver.inner.lock().await;
+            // Pin the Notified future so it persists across loop iterations.
+            // Recreating it each iteration is cancel-unsafe: if select! picks
+            // rx.recv() while a notification is pending, dropping the Notified
+            // loses the permit and the shutdown signal is never observed.
+            let shutdown_notified = shutdown.notified();
+            tokio::pin!(shutdown_notified);
             loop {
                 tokio::select! {
-                    _ = shutdown.notified() => {
+                    _ = &mut shutdown_notified => {
                         callback(ctx.as_ptr(), std::ptr::null_mut());
                         break;
                     }
@@ -2129,33 +2135,34 @@ fn wrap_subscription_response(
         }
 
         /// Convert a BootstrapEvent into a heap-allocated FfiBootstrapEvent.
+        ///
+        /// The `source_id` FfiStr borrows from the boxed record (kept alive
+        /// via `opaque`). The `label` and `entity_id` fields use static
+        /// empty strings — the host currently extracts the full event from
+        /// `opaque` and does not read these metadata fields.
         fn wrap_bootstrap_event(record: BootstrapEvent) -> *mut FfiBootstrapEvent {
-            let source_id_owned = record.source_id.clone();
             let timestamp_us = record
                 .timestamp
                 .timestamp_nanos_opt()
                 .map(|n| n / 1000)
                 .unwrap_or(0);
             let sequence = record.sequence;
-            let entity_id_str = source_change_metadata(&record.change)
-                .map(|m| m.reference.element_id.to_string())
-                .unwrap_or_default();
-            let label_str = source_change_metadata(&record.change)
-                .and_then(|m| m.labels.first().map(|l| l.to_string()))
-                .unwrap_or_default();
 
+            // Box the record first so FfiStr can borrow from the
+            // heap-stable data inside it (same pattern as wrap_source_event).
             let boxed = Box::new(record);
+            let source_id = FfiStr::from_str(&boxed.source_id);
             let opaque = Box::into_raw(boxed) as *mut c_void;
             extern "C" fn drop_bootstrap(ptr: *mut c_void) {
                 unsafe { drop(Box::from_raw(ptr as *mut BootstrapEvent)) };
             }
             Box::into_raw(Box::new(FfiBootstrapEvent {
                 opaque,
-                source_id: FfiStr::from_str(&source_id_owned),
+                source_id,
                 timestamp_us,
                 sequence,
-                label: FfiStr::from_str(&label_str),
-                entity_id: FfiStr::from_str(&entity_id_str),
+                label: FfiStr::from_str(""),
+                entity_id: FfiStr::from_str(""),
                 drop_fn: drop_bootstrap,
             }))
         }
@@ -2172,9 +2179,13 @@ fn wrap_subscription_response(
             let rt_handle = receiver.runtime_handle.clone();
             rt_handle.spawn(async move {
                 let mut rx = receiver.inner.lock().await;
+                // Pin the Notified future for cancel-safe shutdown
+                // (same rationale as change receiver forwarder).
+                let shutdown_notified = shutdown.notified();
+                tokio::pin!(shutdown_notified);
                 loop {
                     tokio::select! {
-                        _ = shutdown.notified() => {
+                        _ = &mut shutdown_notified => {
                             callback(ctx.as_ptr(), std::ptr::null_mut());
                             break;
                         }


### PR DESCRIPTION
## Summary

Fixes several safety and correctness issues in the cdylib FFI plugin event delivery infrastructure that could cause sporadic SIGSEGV crashes, particularly under timing-sensitive conditions like CI environments.

This was triggered by investigating a one-off SIGSEGV in `test_e2e_cdylib_source_query_reaction` observed in [CI run #24480519288](https://github.com/drasi-project/drasi-core/actions/runs/24480519288/job/71543689640?pr=326) on PR #326. The crash occurred ~167ms after subscription (near the mock source's 200ms timer interval), suggesting it happened during the first change event delivery across the FFI boundary. The test passed on re-run, confirming a timing-dependent flake.

## Root Cause Analysis

A deep audit of the FFI plugin infrastructure identified four safety/correctness issues:

### 1. Dangling `FfiStr` pointers in `wrap_bootstrap_event` (UB)

`wrap_bootstrap_event` in `vtable_gen.rs` created `FfiStr` borrowed pointers from **local `String` variables** (`source_id_owned`, `entity_id_str`, `label_str`) that go out of scope when the function returns. The resulting `FfiBootstrapEvent` contained dangling pointers — undefined behavior even though the host currently only reads the `opaque` field.

In contrast, `wrap_source_event` correctly borrows from the **boxed data** (kept alive via the `opaque` raw pointer).

**Fix**: Box the `BootstrapEvent` first, create `source_id` `FfiStr` from the heap-stable boxed reference (matching the `wrap_source_event` pattern), and use static empty strings for the unused `label`/`entity_id` metadata fields.

### 2. Cancel-unsafe `tokio::select!` shutdown in forwarder tasks

Both the change and bootstrap forwarder tasks used `tokio::select!` with `shutdown.notified()` **recreated on each loop iteration**. This is cancel-unsafe: if `select!` picks `rx.recv()` while a shutdown notification is pending, the `Notified` future is dropped, consuming the permit and **permanently losing the shutdown signal**.

While the channel disconnection fallback (`tx.send()` failure) provides a safety net, the forwarder takes a longer/less deterministic path to exit, widening the window for race conditions during teardown.

**Fix**: Pin the `Notified` future once before the loop and reuse it via `&mut` across iterations. This ensures notifications are never lost regardless of which `select!` branch wins.

### 3. Missing `catch_unwind` on `extern "C"` host callbacks

`change_push_callback` and `bootstrap_push_callback` are `extern "C"` functions called from the plugin's tokio runtime. If any code inside panics (e.g., a poisoned mutex), the panic would **unwind across the FFI boundary** — which is undefined behavior that can manifest as SIGSEGV.

**Fix**: Wrap the callback body in `std::panic::catch_unwind` and return `false` (shutdown signal) on panic. The leaked `Arc` is intentionally NOT reclaimed in the panic path because we cannot know which code path panicked; it will be reclaimed when the forwarder task exits normally.

### 4. Inconsistent `FfiBootstrapReceiverState::drop`

`FfiReceiverState::drop` (change receiver) runs the plugin `drop_fn` on a **spawned thread** and joins — this avoids initializing plugin thread-local storage on the caller's thread. `FfiBootstrapReceiverState::drop` called `drop_fn` **directly**, which could initialize plugin TLS on a host tokio worker thread (from `into_mpsc_receiver`'s spawned task).

**Fix**: Use the same spawned-thread-and-join pattern for bootstrap receiver drop.

## Testing

- All 43 host-sdk integration tests pass (42 existing + 1 new)
- New **stress test** (`test_stress_rapid_subscribe_drop_under_load`) exercises 20 rapid subscribe/drop cycles with varying timing:
  - Drop immediately (before forwarder starts)
  - Drop after receiving 1 event
  - Drop after receiving 3 events
  - Drop mid-timer-tick (30ms sleep overlapping with 50ms source interval)
- Clippy clean on modified crates

## Files Changed

| File | Change |
|------|--------|
| `components/plugin-sdk/src/ffi/vtable_gen.rs` | Fix dangling FfiStr in `wrap_bootstrap_event`; pin `Notified` future in both forwarder loops |
| `components/host-sdk/src/proxies/change_receiver.rs` | Add `catch_unwind` to both callbacks; fix bootstrap drop to use spawned thread |
| `components/host-sdk/tests/integration_test.rs` | Add FFI stress test |
