### PR TITLE
feat: MSSQL source replay support with SequencePosition framework widening

### DIFF
--- a/components/indexes/garnet/Cargo.toml
+++ b/components/indexes/garnet/Cargo.toml
@@ -44,6 +44,7 @@ async-recursion = "1.0.4"
 ordered-float = "3.7.0"
 tracing = "0.1.37"
 prost = "0.12.3"
+hex = "0.4"
 
 [dev-dependencies]
 shared-tests = { path = "../../../shared-tests" }

--- a/components/indexes/garnet/src/result_index.rs
+++ b/components/indexes/garnet/src/result_index.rs
@@ -25,6 +25,7 @@ use drasi_core::{
         AccumulatorIndex, IndexError, LazySortedSetStore, ResultIndex, ResultKey, ResultOwner,
         ResultSequence, ResultSequenceCounter,
     },
+    position::SequencePosition,
 };
 use hashers::jenkins::spooky_hash::SpookyHasher;
 use ordered_float::OrderedFloat;
@@ -355,7 +356,7 @@ impl GarnetResultIndex {
 impl ResultSequenceCounter for GarnetResultIndex {
     async fn apply_sequence(
         &self,
-        sequence: u64,
+        sequence: SequencePosition,
         source_change_id: &str,
     ) -> Result<(), IndexError> {
         let seq_key = format!("metadata:{{{}}}:sequence", self.query_id);
@@ -367,7 +368,7 @@ impl ResultSequenceCounter for GarnetResultIndex {
                 "write operation requires an active session",
             ))
         })?;
-        buffer.string_set(seq_key, sequence.to_string().into_bytes());
+        buffer.string_set(seq_key, hex::encode(sequence.as_bytes()).into_bytes());
         buffer.string_set(scid_key, source_change_id.as_bytes().to_vec());
         Ok(())
     }
@@ -392,9 +393,10 @@ impl ResultSequenceCounter for GarnetResultIndex {
         let sequence = match seq_val {
             BufferReadResult::Found(bytes) => {
                 let s = String::from_utf8(bytes).map_err(IndexError::other)?;
-                s.parse::<u64>().map_err(IndexError::other)?
+                let decoded = hex::decode(s).map_err(IndexError::other)?;
+                SequencePosition::try_from_bytes(&decoded).map_err(IndexError::other)?
             }
-            BufferReadResult::KeyDeleted => 0,
+            BufferReadResult::KeyDeleted => SequencePosition::default(),
             BufferReadResult::NotInBuffer => {
                 return self.get_sequence_from_redis().await;
             }
@@ -422,10 +424,14 @@ impl GarnetResultIndex {
         let mut con = self.connection.clone();
 
         let sequence = match con
-            .get::<String, Option<u64>>(format!("metadata:{{{}}}:sequence", self.query_id))
+            .get::<String, Option<String>>(format!("metadata:{{{}}}:sequence", self.query_id))
             .await
         {
-            Ok(v) => v.unwrap_or(0),
+            Ok(Some(s)) => {
+                let decoded = hex::decode(s).map_err(IndexError::other)?;
+                SequencePosition::try_from_bytes(&decoded).map_err(IndexError::other)?
+            }
+            Ok(None) => SequencePosition::default(),
             Err(e) => return Err(IndexError::other(e)),
         };
 

--- a/components/indexes/garnet/tests/scenario_tests.rs
+++ b/components/indexes/garnet/tests/scenario_tests.rs
@@ -24,6 +24,7 @@ use drasi_core::{
         cached_element_index::CachedElementIndex, cached_result_index::CachedResultIndex,
     },
     interface::ElementIndex,
+    position::SequencePosition,
     query::QueryBuilder,
 };
 use shared_tests::QueryTestConfig;
@@ -445,6 +446,7 @@ mod session {
             ResultOwner, ResultSequenceCounter, SessionControl,
         },
         models::{Element, ElementMetadata, ElementPropertyMap, ElementReference},
+        position::SequencePosition,
     };
     use drasi_index_garnet::{
         element_index::GarnetElementIndex, future_queue::GarnetFutureQueue,
@@ -1095,23 +1097,33 @@ mod session {
 
         // Commit sequence 5
         session_control.begin().await.unwrap();
-        result_index.apply_sequence(5, "change-1").await.unwrap();
+        result_index
+            .apply_sequence(SequencePosition::from_u64(5), "change-1")
+            .await
+            .unwrap();
         session_control.commit().await.unwrap();
 
         // Verify it persisted
         session_control.begin().await.unwrap();
         let seq = result_index.get_sequence().await.unwrap();
-        assert_eq!(seq.sequence, 5);
+        assert_eq!(seq.sequence, SequencePosition::from_u64(5));
         assert_eq!(seq.source_change_id.as_ref(), "change-1");
 
         // Apply sequence 10 then rollback
-        result_index.apply_sequence(10, "change-2").await.unwrap();
+        result_index
+            .apply_sequence(SequencePosition::from_u64(10), "change-2")
+            .await
+            .unwrap();
         session_control.rollback().unwrap();
 
         // Verify rollback preserved the old value
         session_control.begin().await.unwrap();
         let seq = result_index.get_sequence().await.unwrap();
-        assert_eq!(seq.sequence, 5, "sequence should not change after rollback");
+        assert_eq!(
+            seq.sequence,
+            SequencePosition::from_u64(5),
+            "sequence should not change after rollback"
+        );
         assert_eq!(
             seq.source_change_id.as_ref(),
             "change-1",
@@ -1119,13 +1131,16 @@ mod session {
         );
 
         // Now commit sequence 10
-        result_index.apply_sequence(10, "change-2").await.unwrap();
+        result_index
+            .apply_sequence(SequencePosition::from_u64(10), "change-2")
+            .await
+            .unwrap();
         session_control.commit().await.unwrap();
 
         // Verify it persisted
         session_control.begin().await.unwrap();
         let seq = result_index.get_sequence().await.unwrap();
-        assert_eq!(seq.sequence, 10);
+        assert_eq!(seq.sequence, SequencePosition::from_u64(10));
         assert_eq!(seq.source_change_id.as_ref(), "change-2");
         session_control.rollback().unwrap();
     }

--- a/components/indexes/rocksdb/src/result_index.rs
+++ b/components/indexes/rocksdb/src/result_index.rs
@@ -24,6 +24,7 @@ use drasi_core::{
         AccumulatorIndex, IndexError, LazySortedSetStore, ResultIndex, ResultKey, ResultOwner,
         ResultSequence, ResultSequenceCounter,
     },
+    position::SequencePosition,
 };
 use hashers::jenkins::spooky_hash::SpookyHasher;
 use ordered_float::OrderedFloat;
@@ -294,7 +295,7 @@ impl LazySortedSetStore for RocksDbResultIndex {
 impl ResultSequenceCounter for RocksDbResultIndex {
     async fn apply_sequence(
         &self,
-        sequence: u64,
+        sequence: SequencePosition,
         source_change_id: &str,
     ) -> Result<(), IndexError> {
         let db = self.db.clone();
@@ -304,7 +305,7 @@ impl ResultSequenceCounter for RocksDbResultIndex {
             let metadata_cf = db.cf_handle(METADATA_CF).expect("metadata cf not found");
 
             session_state.with_txn(|txn| {
-                txn.put_cf(&metadata_cf, "sequence", sequence.to_be_bytes())
+                txn.put_cf(&metadata_cf, "sequence", sequence.as_bytes())
                     .map_err(IndexError::other)?;
                 txn.put_cf(
                     &metadata_cf,
@@ -331,11 +332,8 @@ impl ResultSequenceCounter for RocksDbResultIndex {
                 let seq_data = txn.get_cf(&metadata_cf, "sequence");
                 match seq_data {
                     Ok(Some(v)) => {
-                        let seq_bytes: [u8; 8] = match v.try_into() {
-                            Ok(v) => v,
-                            Err(_) => return Err(IndexError::CorruptedData),
-                        };
-                        let sequence: u64 = u64::from_be_bytes(seq_bytes);
+                        let sequence =
+                            SequencePosition::try_from_bytes(&v).map_err(IndexError::other)?;
 
                         let source_change_id_data = txn.get_cf(&metadata_cf, "source_change_id");
 

--- a/components/sources/mssql/src/lib.rs
+++ b/components/sources/mssql/src/lib.rs
@@ -91,6 +91,7 @@ pub use lsn::Lsn;
 
 use anyhow::Result;
 use async_trait::async_trait;
+use drasi_lib::position::SequencePosition;
 use drasi_lib::sources::base::{SourceBase, SourceBaseParams};
 use drasi_lib::sources::Source;
 use drasi_lib::state_store::StateStoreProvider;
@@ -122,6 +123,10 @@ pub struct MsSqlSource {
 
     /// Shutdown signal receiver (cloned for each task)
     shutdown_rx: watch::Receiver<bool>,
+
+    /// Resume position from the last subscriber (if replay was requested).
+    /// Written by `subscribe()`, consumed once by `start()`.
+    resume_from: Arc<RwLock<Option<SequencePosition>>>,
 }
 
 impl MsSqlSource {
@@ -147,6 +152,7 @@ impl MsSqlSource {
             task_handle: Arc::new(RwLock::new(None)),
             shutdown_tx,
             shutdown_rx,
+            resume_from: Arc::new(RwLock::new(None)),
         })
     }
 
@@ -247,6 +253,10 @@ impl Source for MsSqlSource {
         self.base.get_auto_start()
     }
 
+    fn supports_replay(&self) -> bool {
+        true
+    }
+
     async fn status(&self) -> drasi_lib::channels::ComponentStatus {
         self.base.get_status().await
     }
@@ -267,6 +277,9 @@ impl Source for MsSqlSource {
         let state_store = self.state_store.read().await.clone();
         let shutdown_rx = self.shutdown_rx.clone();
 
+        // Consume the pending resume position (if any)
+        let resume_from = self.resume_from.write().await.take();
+
         // Spawn CDC polling task
         let task_handle = tokio::spawn(async move {
             if let Err(e) = stream::run_cdc_stream(
@@ -275,6 +288,7 @@ impl Source for MsSqlSource {
                 dispatchers,
                 state_store,
                 shutdown_rx,
+                resume_from,
             )
             .await
             {
@@ -326,6 +340,45 @@ impl Source for MsSqlSource {
         &self,
         settings: drasi_lib::config::SourceSubscriptionSettings,
     ) -> Result<drasi_lib::channels::SubscriptionResponse> {
+        use drasi_lib::sources::SourceError;
+
+        // If resume_from is requested, validate the position against CDC retention
+        if let Some(ref resume_pos) = settings.resume_from {
+            let seek_lsn = stream::position_to_seek_lsn(resume_pos)?;
+
+            // Connect briefly to check min_lsn for each tracked table
+            let mut conn = MsSqlConnection::connect(&self.config).await?;
+
+            for table in &self.config.tables {
+                let min_lsn = stream::get_min_lsn(conn.client_mut(), table).await?;
+
+                if seek_lsn < min_lsn {
+                    let earliest_pos = stream::cdc_position(&min_lsn, &Lsn::zero());
+                    return Err(SourceError::PositionUnavailable {
+                        source_id: self.source_id.clone(),
+                        requested: *resume_pos,
+                        earliest_available: Some(earliest_pos),
+                    }
+                    .into());
+                }
+            }
+
+            // Store for consumption by start(). If multiple subscribers request
+            // different resume positions before the next restart, keep the earliest
+            // position so replay satisfies all subscribers.
+            let mut stored = self.resume_from.write().await;
+            match *stored {
+                Some(existing) => {
+                    if *resume_pos < existing {
+                        *stored = Some(*resume_pos);
+                    }
+                }
+                None => {
+                    *stored = Some(*resume_pos);
+                }
+            }
+        }
+
         self.base
             .subscribe_with_bootstrap(&settings, "MS SQL")
             .await
@@ -496,6 +549,7 @@ impl MsSqlSourceBuilder {
             task_handle: Arc::new(RwLock::new(None)),
             shutdown_tx,
             shutdown_rx,
+            resume_from: Arc::new(RwLock::new(None)),
         })
     }
 }

--- a/components/sources/mssql/src/stream.rs
+++ b/components/sources/mssql/src/stream.rs
@@ -23,7 +23,8 @@ use crate::lsn::Lsn;
 use crate::types::extract_properties_from_cdc_row;
 use anyhow::{anyhow, Result};
 use drasi_core::models::{Element, ElementMetadata, ElementReference, SourceChange};
-use drasi_lib::channels::{ChangeDispatcher, SourceEventWrapper};
+use drasi_core::position::SequencePosition;
+use drasi_lib::channels::{ChangeDispatcher, SourceEvent, SourceEventWrapper};
 use log::{debug, error, info, warn};
 use std::sync::Arc;
 use std::time::Duration;
@@ -41,6 +42,33 @@ fn classify_error(error: &anyhow::Error) -> MsSqlErrorKind {
     MsSqlError::classify(error).unwrap_or(MsSqlErrorKind::Other)
 }
 
+/// Construct a 20-byte CDC position from start_lsn and seqval.
+///
+/// The position is `start_lsn (10 bytes) || seqval (10 bytes)`, which is
+/// lexicographically ordered (matching CDC's natural ordering) and uniquely
+/// identifies a single CDC row.
+pub fn cdc_position(start_lsn: &Lsn, seqval: &Lsn) -> SequencePosition {
+    let mut bytes = [0u8; 20];
+    bytes[..10].copy_from_slice(start_lsn.as_bytes());
+    bytes[10..20].copy_from_slice(seqval.as_bytes());
+    SequencePosition::from_bytes(&bytes)
+}
+
+/// Extract the start_lsn from a 20-byte CDC position.
+///
+/// Returns the first 10 bytes as an `Lsn`, suitable for seeking into the CDC
+/// stream with `fn_cdc_get_all_changes_*`.
+pub fn position_to_seek_lsn(pos: &SequencePosition) -> Result<Lsn> {
+    let bytes = pos.as_bytes();
+    if bytes.len() != 20 {
+        return Err(anyhow!(
+            "Expected 20-byte MSSQL CDC position, got {} bytes",
+            bytes.len()
+        ));
+    }
+    Lsn::from_bytes(&bytes[..10])
+}
+
 /// Run the CDC polling loop with automatic reconnection
 ///
 /// This continuously polls MS SQL CDC for changes and dispatches them to subscribers.
@@ -52,10 +80,22 @@ pub async fn run_cdc_stream(
     dispatchers: Arc<RwLock<Vec<Box<dyn ChangeDispatcher<SourceEventWrapper> + Send + Sync>>>>,
     state_store: Option<Arc<dyn drasi_lib::state_store::StateStoreProvider>>,
     mut shutdown_rx: watch::Receiver<bool>,
+    resume_from: Option<SequencePosition>,
 ) -> Result<()> {
     info!("Starting CDC stream for source '{source_id}'");
 
     let mut reconnect_delay = Duration::from_millis(INITIAL_RECONNECT_DELAY_MS);
+
+    // If resume_from is provided, derive the starting LSN from the position.
+    // This overrides the checkpoint and start_position config.
+    let resume_lsn = match resume_from {
+        Some(pos) => {
+            let lsn = position_to_seek_lsn(&pos)?;
+            info!("Resuming from position, seek LSN: {}", lsn.to_hex());
+            Some((lsn, pos))
+        }
+        None => None,
+    };
 
     // Outer reconnection loop
     loop {
@@ -71,6 +111,7 @@ pub async fn run_cdc_stream(
             &dispatchers,
             &state_store,
             &mut shutdown_rx,
+            &resume_lsn,
         )
         .await
         {
@@ -138,6 +179,7 @@ async fn run_cdc_polling_loop(
     dispatchers: &Arc<RwLock<Vec<Box<dyn ChangeDispatcher<SourceEventWrapper> + Send + Sync>>>>,
     state_store: &Option<Arc<dyn drasi_lib::state_store::StateStoreProvider>>,
     shutdown_rx: &mut watch::Receiver<bool>,
+    resume_lsn: &Option<(Lsn, SequencePosition)>,
 ) -> Result<()> {
     // Connect to MS SQL
     info!("Connecting to MS SQL Server for source '{source_id}'");
@@ -149,8 +191,19 @@ async fn run_cdc_polling_loop(
     pk_cache.discover_keys(client, config).await?;
     info!("Discovered primary keys for {} tables", config.tables.len());
 
-    // Load last LSN checkpoint from StateStore
-    let mut current_lsn = load_checkpoint(source_id, state_store).await?;
+    // Determine starting LSN.
+    // Priority: resume_from > checkpoint > start_position config
+    let mut current_lsn = if let Some((lsn, _pos)) = resume_lsn {
+        info!("Using resume LSN: {}", lsn.to_hex());
+        Some(*lsn)
+    } else {
+        load_checkpoint(source_id, state_store).await?
+    };
+
+    // Track the resume position for filtering during the catch-up batch.
+    // Events with position ≤ resume_from are skipped to avoid reprocessing.
+    let mut skip_threshold: Option<SequencePosition> = resume_lsn.as_ref().map(|(_lsn, pos)| *pos);
+
     info!(
         "Starting CDC from LSN: {}",
         current_lsn
@@ -182,6 +235,7 @@ async fn run_cdc_polling_loop(
             &pk_cache,
             &mut current_lsn,
             dispatchers,
+            &mut skip_threshold,
         )
         .await
         {
@@ -258,6 +312,7 @@ async fn poll_cdc_changes(
     pk_cache: &PrimaryKeyCache,
     current_lsn: &mut Option<Lsn>,
     dispatchers: &Arc<RwLock<Vec<Box<dyn ChangeDispatcher<SourceEventWrapper> + Send + Sync>>>>,
+    skip_threshold: &mut Option<SequencePosition>,
 ) -> Result<usize> {
     // Get current max LSN from CDC
     let max_lsn = get_max_lsn(client).await?;
@@ -312,8 +367,12 @@ async fn poll_cdc_changes(
         *current_lsn = Some(from_lsn);
     }
 
-    // If from_lsn >= max_lsn, no new changes
-    if from_lsn >= max_lsn {
+    // If from_lsn > max_lsn, no new changes.
+    // Note: we use strict > (not >=) because the CDC range [from_lsn, max_lsn]
+    // is inclusive on both ends. When from_lsn == max_lsn (e.g. during resume),
+    // there may still be rows at that LSN to process; skip_threshold handles
+    // filtering already-seen rows.
+    if from_lsn > max_lsn {
         debug!(
             "No new changes: from_lsn {} >= max_lsn {}",
             from_lsn.to_hex(),
@@ -329,7 +388,7 @@ async fn poll_cdc_changes(
     );
 
     let mut change_count = 0;
-    let mut batch = Vec::new();
+    let mut batch: Vec<(SourceChange, SequencePosition)> = Vec::new();
 
     // Query each configured table's CDC changes
     for table in &config.tables {
@@ -348,6 +407,23 @@ async fn poll_cdc_changes(
             // Extract CDC metadata
             let operation = extract_operation(&row)?;
 
+            // Skip update before images - we only care about after
+            if operation == CdcOperation::UpdateBefore {
+                continue;
+            }
+
+            // Extract position components for sequence stamping
+            let start_lsn = extract_lsn(&row)?;
+            let seqval = extract_seqval(&row)?;
+            let position = cdc_position(&start_lsn, &seqval);
+
+            // During resume, skip events that were already processed
+            if let Some(threshold) = skip_threshold {
+                if position <= *threshold {
+                    continue;
+                }
+            }
+
             // Generate element ID from primary key
             let element_id = pk_cache.generate_element_id(table, &row)?;
 
@@ -363,7 +439,7 @@ async fn poll_cdc_changes(
                             metadata: ElementMetadata {
                                 reference: ElementReference::new(source_id, &element_id),
                                 labels: Arc::from([Arc::from(label)]),
-                                effective_from: 0, // Will be set by dispatcher
+                                effective_from: 0,
                             },
                             properties,
                         },
@@ -389,24 +465,32 @@ async fn poll_cdc_changes(
                         effective_from: 0,
                     },
                 },
-                CdcOperation::UpdateBefore => {
-                    // Skip update before images - we only care about after
-                    continue;
-                }
+                CdcOperation::UpdateBefore => unreachable!("filtered above"),
             };
 
-            batch.push(change);
+            batch.push((change, position));
             change_count += 1;
         }
     }
 
-    // After processing all changes, update checkpoint to max_lsn
-    // This ensures we don't reprocess the same changes
-    if change_count > 0 {
-        *current_lsn = Some(max_lsn);
+    // Clear skip_threshold after the first poll that actually queried rows —
+    // even if every row was filtered, the threshold has served its purpose.
+    // Also advance current_lsn past max_lsn so we don't re-query the same
+    // inclusive range when all rows were filtered by skip_threshold.
+    if skip_threshold.is_some() {
+        let next_lsn = increment_lsn(client, &max_lsn).await?;
+        *current_lsn = Some(next_lsn);
+        *skip_threshold = None;
+    } else if change_count > 0 {
+        // Normal (non-resume) path: advance past max_lsn after processing.
+        let next_lsn = increment_lsn(client, &max_lsn).await?;
+        *current_lsn = Some(next_lsn);
     }
 
-    // Dispatch all changes in batch
+    // Sort batch by position to ensure strict ordering across tables
+    batch.sort_by_key(|(_, pos)| *pos);
+
+    // Dispatch all changes in batch with sequence positions
     if !batch.is_empty() {
         debug!(
             "Dispatching {} changes to {} dispatchers",
@@ -415,15 +499,16 @@ async fn poll_cdc_changes(
         );
         let dispatchers = dispatchers.read().await;
         for dispatcher in dispatchers.iter() {
-            for change in &batch {
+            for (change, position) in &batch {
                 let mut profiling = drasi_lib::profiling::ProfilingMetadata::new();
                 profiling.source_send_ns = Some(drasi_lib::profiling::timestamp_ns());
 
-                let wrapper = SourceEventWrapper::with_profiling(
+                let wrapper = SourceEventWrapper::with_sequence(
                     source_id.to_string(),
-                    drasi_lib::channels::SourceEvent::Change(change.clone()),
+                    SourceEvent::Change(change.clone()),
                     chrono::Utc::now(),
-                    profiling,
+                    *position,
+                    Some(profiling),
                 );
                 dispatcher.dispatch_change(Arc::new(wrapper)).await?;
             }
@@ -500,7 +585,7 @@ async fn get_max_lsn(
 }
 
 /// Get minimum LSN for a table's CDC capture instance
-async fn get_min_lsn(
+pub async fn get_min_lsn(
     client: &mut tiberius::Client<tokio_util::compat::Compat<tokio::net::TcpStream>>,
     table: &str,
 ) -> Result<Lsn> {
@@ -585,6 +670,50 @@ fn extract_lsn(row: &tiberius::Row) -> Result<Lsn> {
     Lsn::from_bytes(lsn_bytes)
 }
 
+/// Extract seqval (sequence value within transaction) from CDC row
+fn extract_seqval(row: &tiberius::Row) -> Result<Lsn> {
+    let col_idx = row
+        .columns()
+        .iter()
+        .position(|c| c.name() == cdc_columns::SEQVAL)
+        .ok_or_else(|| anyhow!("CDC row missing __$seqval column"))?;
+
+    let seqval_bytes: &[u8] = row
+        .try_get(col_idx)?
+        .ok_or_else(|| anyhow!("__$seqval is NULL"))?;
+
+    Lsn::from_bytes(seqval_bytes)
+}
+
+/// Increment an LSN using `sys.fn_cdc_increment_lsn`.
+///
+/// This is used to advance past a boundary so the next poll's inclusive range
+/// does not reprocess the last row from the previous batch.
+async fn increment_lsn(
+    client: &mut tiberius::Client<tokio_util::compat::Compat<tokio::net::TcpStream>>,
+    lsn: &Lsn,
+) -> Result<Lsn> {
+    let lsn_bytes = lsn.to_bytes();
+    let stream = client
+        .query(
+            "SELECT sys.fn_cdc_increment_lsn(@P1) AS next_lsn",
+            &[&lsn_bytes.as_slice()],
+        )
+        .await?;
+
+    let rows = stream.into_first_result().await?;
+    if rows.is_empty() {
+        return Err(anyhow!("No result from fn_cdc_increment_lsn"));
+    }
+
+    let row = &rows[0];
+    let next_bytes: &[u8] = row
+        .try_get(0)?
+        .ok_or_else(|| anyhow!("fn_cdc_increment_lsn returned NULL"))?;
+
+    Lsn::from_bytes(next_bytes)
+}
+
 /// Load LSN checkpoint from StateStore
 async fn load_checkpoint(
     source_id: &str,
@@ -644,6 +773,49 @@ mod tests {
         let table = "orders";
         let capture_instance = format!("dbo_{table}");
         assert_eq!(capture_instance, "dbo_orders");
+    }
+
+    #[test]
+    fn test_cdc_position_roundtrip() {
+        let lsn = Lsn::from_hex("0000002700000019c002").unwrap();
+        let seqval = Lsn::from_hex("0000002700000019c003").unwrap();
+
+        let pos = cdc_position(&lsn, &seqval);
+        assert_eq!(pos.as_bytes().len(), 20);
+
+        let extracted = position_to_seek_lsn(&pos).unwrap();
+        assert_eq!(extracted, lsn);
+    }
+
+    #[test]
+    fn test_cdc_position_ordering() {
+        // Same LSN, different seqval → position ordering follows seqval
+        let lsn = Lsn::from_hex("0000002700000019c002").unwrap();
+        let seq_a = Lsn::from_hex("0000002700000019c001").unwrap();
+        let seq_b = Lsn::from_hex("0000002700000019c002").unwrap();
+
+        let pos_a = cdc_position(&lsn, &seq_a);
+        let pos_b = cdc_position(&lsn, &seq_b);
+        assert!(pos_a < pos_b);
+    }
+
+    #[test]
+    fn test_cdc_position_ordering_different_lsn() {
+        // Different LSNs → ordered by LSN regardless of seqval
+        let lsn_a = Lsn::from_hex("0000002700000019c001").unwrap();
+        let lsn_b = Lsn::from_hex("0000002700000019c002").unwrap();
+        let seqval = Lsn::zero();
+
+        let pos_a = cdc_position(&lsn_a, &seqval);
+        let pos_b = cdc_position(&lsn_b, &seqval);
+        assert!(pos_a < pos_b);
+    }
+
+    #[test]
+    fn test_position_to_seek_lsn_rejects_wrong_size() {
+        let bad_pos = SequencePosition::from_u64(42);
+        let result = position_to_seek_lsn(&bad_pos);
+        assert!(result.is_err());
     }
 
     #[test]

--- a/components/sources/mssql/tests/replay_test.rs
+++ b/components/sources/mssql/tests/replay_test.rs
@@ -1,0 +1,557 @@
+// Copyright 2025 The Drasi Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Replay integration tests for MSSQL source.
+//!
+//! These tests verify:
+//! - CDC events carry sequence positions
+//! - Resume from a position filters already-seen events
+//! - Subscribe rejects expired positions with PositionUnavailable
+//!
+//! Run with:
+//!   cargo test -p drasi-source-mssql --test replay_test -- --ignored --nocapture
+
+mod mssql_helpers;
+
+use anyhow::{Context, Result};
+use drasi_lib::channels::SourceEventWrapper;
+use drasi_lib::component_graph::ComponentGraph;
+use drasi_lib::config::SourceSubscriptionSettings;
+use drasi_lib::context::SourceRuntimeContext;
+use drasi_lib::sources::{Source, SourceError};
+use drasi_source_mssql::lsn::Lsn;
+use drasi_source_mssql::stream::{cdc_position, position_to_seek_lsn};
+use drasi_source_mssql::{MsSqlSource, StartPosition};
+use mssql_helpers::{execute_sql, setup_mssql, MssqlConfig};
+use std::collections::HashSet;
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::time::{sleep, timeout};
+
+const TEST_DB: &str = "DrasiReplayTest";
+const TEST_TABLE: &str = "dbo.Products";
+const SOURCE_ID: &str = "replay-source";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn make_source(config: &MssqlConfig, start_pos: StartPosition) -> Result<MsSqlSource> {
+    MsSqlSource::builder(SOURCE_ID)
+        .with_host(&config.host)
+        .with_port(config.port)
+        .with_database(&config.database)
+        .with_user(&config.user)
+        .with_password(&config.password)
+        .with_table(TEST_TABLE)
+        .with_poll_interval_ms(500)
+        .with_start_position(start_pos)
+        .with_trust_server_certificate(true)
+        .build()
+        .context("Failed to build MsSqlSource")
+}
+
+fn make_context() -> SourceRuntimeContext {
+    let (graph, _rx) = ComponentGraph::new("replay-test");
+    SourceRuntimeContext::new("replay-test", SOURCE_ID, None, graph.update_sender(), None)
+}
+
+fn make_settings(
+    resume_from: Option<drasi_lib::position::SequencePosition>,
+) -> SourceSubscriptionSettings {
+    SourceSubscriptionSettings {
+        source_id: SOURCE_ID.to_string(),
+        enable_bootstrap: false,
+        query_id: "replay-query".to_string(),
+        nodes: HashSet::new(),
+        relations: HashSet::new(),
+        resume_from,
+        request_position_handle: false,
+    }
+}
+
+/// Receive events from the source with a per-event timeout.
+/// Returns all events collected before the timeout fires on a recv.
+async fn collect_events(
+    receiver: &mut Box<dyn drasi_lib::channels::ChangeReceiver<SourceEventWrapper>>,
+    per_event_timeout: Duration,
+    max_events: usize,
+) -> Vec<Arc<SourceEventWrapper>> {
+    let mut events = Vec::new();
+    for _ in 0..max_events {
+        match timeout(per_event_timeout, receiver.recv()).await {
+            Ok(Ok(event)) => events.push(event),
+            _ => break,
+        }
+    }
+    events
+}
+
+async fn prepare_database(config: &MssqlConfig) -> Result<MssqlConfig> {
+    let mut client = config.connect().await?;
+    execute_sql(
+        &mut client,
+        &format!("IF DB_ID('{TEST_DB}') IS NULL CREATE DATABASE [{TEST_DB}]"),
+    )
+    .await?;
+    drop(client);
+
+    let mut db_config = config.clone();
+    db_config.database = TEST_DB.to_string();
+    let mut db_client = db_config.connect().await?;
+
+    execute_sql(
+        &mut db_client,
+        "IF NOT EXISTS (SELECT 1 FROM sys.databases WHERE name = DB_NAME() AND is_cdc_enabled = 1) \
+         EXEC sys.sp_cdc_enable_db;",
+    )
+    .await?;
+
+    execute_sql(
+        &mut db_client,
+        "IF OBJECT_ID('dbo.Products', 'U') IS NOT NULL BEGIN \
+             IF EXISTS (SELECT 1 FROM sys.tables WHERE name = 'Products' AND is_tracked_by_cdc = 1) \
+                 EXEC sys.sp_cdc_disable_table @source_schema = 'dbo', @source_name = 'Products', @capture_instance = 'all'; \
+             DROP TABLE dbo.Products; \
+         END",
+    )
+    .await?;
+
+    execute_sql(
+        &mut db_client,
+        "CREATE TABLE dbo.Products (
+            ProductId INT PRIMARY KEY,
+            Name NVARCHAR(100) NOT NULL,
+            Price DECIMAL(10,2) NOT NULL
+        );",
+    )
+    .await?;
+
+    execute_sql(
+        &mut db_client,
+        "IF NOT EXISTS (SELECT 1 FROM sys.tables WHERE name = 'Products' AND is_tracked_by_cdc = 1) \
+             EXEC sys.sp_cdc_enable_table @source_schema = 'dbo', @source_name = 'Products', @role_name = NULL;",
+    )
+    .await?;
+
+    Ok(db_config)
+}
+
+/// Wait until the CDC change table contains at least `expected` rows.
+async fn wait_for_cdc_rows(config: &MssqlConfig, expected: usize) -> Result<()> {
+    for _ in 0..30 {
+        let mut client = config.connect().await?;
+        let stream = client
+            .query(
+                "SELECT COUNT(*) FROM cdc.dbo_Products_CT WHERE __$operation = 2",
+                &[],
+            )
+            .await?;
+        let rows = stream.into_first_result().await?;
+        if let Some(row) = rows.first() {
+            let count: i32 = row.get(0).unwrap_or(0);
+            if count as usize >= expected {
+                return Ok(());
+            }
+        }
+        sleep(Duration::from_millis(500)).await;
+    }
+    anyhow::bail!("Timed out waiting for {expected} CDC rows");
+}
+
+/// Query CDC change table to get (start_lsn, seqval) pairs for inserts,
+/// ordered by position. Returns one entry per inserted ProductId.
+async fn get_cdc_positions(config: &MssqlConfig) -> Result<Vec<(i32, Lsn, Lsn)>> {
+    let mut client = config.connect().await?;
+    let stream = client
+        .query(
+            "SELECT ProductId, __$start_lsn, __$seqval \
+             FROM cdc.dbo_Products_CT \
+             WHERE __$operation = 2 \
+             ORDER BY __$start_lsn, __$seqval",
+            &[],
+        )
+        .await?;
+    let rows = stream.into_first_result().await?;
+
+    let mut result = Vec::new();
+    for row in &rows {
+        let product_id: i32 = row
+            .get(0)
+            .ok_or_else(|| anyhow::anyhow!("NULL ProductId"))?;
+        let lsn_bytes: &[u8] = row
+            .try_get(1)?
+            .ok_or_else(|| anyhow::anyhow!("NULL __$start_lsn"))?;
+        let seqval_bytes: &[u8] = row
+            .try_get(2)?
+            .ok_or_else(|| anyhow::anyhow!("NULL __$seqval"))?;
+        let start_lsn = Lsn::from_bytes(lsn_bytes)?;
+        let seqval = Lsn::from_bytes(seqval_bytes)?;
+        result.push((product_id, start_lsn, seqval));
+    }
+
+    Ok(result)
+}
+
+/// Extract the product IDs from source events (CDC insert/update/delete).
+fn extract_product_ids(events: &[Arc<SourceEventWrapper>]) -> Vec<String> {
+    use drasi_lib::channels::SourceEvent;
+
+    events
+        .iter()
+        .filter_map(|e| match &e.event {
+            SourceEvent::Change(change) => {
+                let elem = match change {
+                    drasi_core::models::SourceChange::Insert { element } => Some(element),
+                    drasi_core::models::SourceChange::Update { element } => Some(element),
+                    drasi_core::models::SourceChange::Delete { metadata } => {
+                        return Some(metadata.reference.element_id.to_string());
+                    }
+                    _ => None,
+                };
+                elem.map(|e| match e {
+                    drasi_core::models::Element::Node { metadata, .. } => {
+                        metadata.reference.element_id.to_string()
+                    }
+                    drasi_core::models::Element::Relation { metadata, .. } => {
+                        metadata.reference.element_id.to_string()
+                    }
+                })
+            }
+            _ => None,
+        })
+        .collect()
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+/// Verify that CDC events emitted by the MSSQL source carry non-None
+/// sequence positions that are monotonically increasing.
+#[tokio::test]
+#[ignore]
+#[cfg(not(target_arch = "aarch64"))]
+async fn test_mssql_replay_events_carry_sequence_positions() -> Result<()> {
+    let _ = env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info"))
+        .is_test(true)
+        .try_init();
+
+    let result = timeout(Duration::from_secs(300), async {
+        let mssql = setup_mssql()
+            .await
+            .context("Failed to start MSSQL container")?;
+        let db_config = prepare_database(mssql.config())
+            .await
+            .context("Failed to prepare database")?;
+
+        // Start source with Beginning so we pick up everything
+        let source = make_source(&db_config, StartPosition::Beginning)?;
+        let ctx = make_context();
+        source.initialize(ctx).await;
+
+        let response = source.subscribe(make_settings(None)).await?;
+        let mut receiver = response.receiver;
+
+        source.start().await?;
+
+        // Give the source time to initialize its CDC polling loop
+        sleep(Duration::from_secs(3)).await;
+
+        // Insert two rows (separate transactions for distinct positions)
+        let mut client = db_config.connect().await?;
+        execute_sql(
+            &mut client,
+            "INSERT INTO dbo.Products (ProductId, Name, Price) VALUES (1, 'Widget', 10.00);",
+        )
+        .await?;
+        execute_sql(
+            &mut client,
+            "INSERT INTO dbo.Products (ProductId, Name, Price) VALUES (2, 'Gadget', 20.00);",
+        )
+        .await?;
+
+        // Collect events
+        let events = collect_events(&mut receiver, Duration::from_secs(15), 10).await;
+
+        // We should have at least 2 CDC change events
+        assert!(
+            events.len() >= 2,
+            "Expected at least 2 events, got {}",
+            events.len()
+        );
+
+        // Every event should have a sequence position
+        for (i, event) in events.iter().enumerate() {
+            assert!(
+                event.sequence.is_some(),
+                "Event {i} has no sequence position"
+            );
+        }
+
+        // Positions should be strictly increasing
+        let positions: Vec<_> = events.iter().filter_map(|e| e.sequence).collect();
+        for window in positions.windows(2) {
+            assert!(
+                window[0] < window[1],
+                "Positions not strictly increasing: {:?} >= {:?}",
+                window[0],
+                window[1]
+            );
+        }
+
+        source.stop().await?;
+        mssql.cleanup().await;
+
+        Ok::<(), anyhow::Error>(())
+    })
+    .await;
+
+    match result {
+        Ok(inner) => inner?,
+        Err(_) => anyhow::bail!("Test timed out after 300 seconds"),
+    }
+
+    Ok(())
+}
+
+/// Verify that resuming from a CDC position filters out already-seen events.
+///
+/// Inserts 3 rows in a single transaction (same start_lsn, different seqval),
+/// resumes from row 2's position, and verifies only row 3 arrives.
+#[tokio::test]
+#[ignore]
+#[cfg(not(target_arch = "aarch64"))]
+async fn test_mssql_replay_resume_filters_already_seen() -> Result<()> {
+    let _ = env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info"))
+        .is_test(true)
+        .try_init();
+
+    let result = timeout(Duration::from_secs(300), async {
+        let mssql = setup_mssql()
+            .await
+            .context("Failed to start MSSQL container")?;
+        let db_config = prepare_database(mssql.config())
+            .await
+            .context("Failed to prepare database")?;
+
+        // Step 1: Insert 3 rows in a single transaction so they share start_lsn
+        let mut client = db_config.connect().await?;
+        execute_sql(
+            &mut client,
+            "BEGIN TRANSACTION; \
+             INSERT INTO dbo.Products (ProductId, Name, Price) VALUES (1, 'Alpha', 10.00); \
+             INSERT INTO dbo.Products (ProductId, Name, Price) VALUES (2, 'Beta', 20.00); \
+             INSERT INTO dbo.Products (ProductId, Name, Price) VALUES (3, 'Gamma', 30.00); \
+             COMMIT;",
+        )
+        .await?;
+
+        // Step 2: Wait for CDC to capture all 3 inserts
+        wait_for_cdc_rows(&db_config, 3)
+            .await
+            .context("CDC did not capture 3 rows in time")?;
+
+        // Step 3: Get the CDC positions for each row
+        let positions = get_cdc_positions(&db_config).await?;
+        assert!(
+            positions.len() >= 3,
+            "Expected 3 CDC positions, got {}",
+            positions.len()
+        );
+
+        // Find positions for rows 1, 2, 3
+        let row2_entry = positions
+            .iter()
+            .find(|(pid, _, _)| *pid == 2)
+            .ok_or_else(|| anyhow::anyhow!("No CDC position for ProductId=2"))?;
+        let resume_pos = cdc_position(&row2_entry.1, &row2_entry.2);
+
+        log::info!(
+            "Resuming from position of row 2: seek_lsn={}, position={:?}",
+            row2_entry.1.to_hex(),
+            resume_pos
+        );
+
+        // Step 4: Create source with resume_from = row 2's position
+        let source = make_source(&db_config, StartPosition::Beginning)?;
+        let ctx = make_context();
+        source.initialize(ctx).await;
+
+        let response = source
+            .subscribe(make_settings(Some(resume_pos)))
+            .await
+            .context("subscribe with resume_from failed")?;
+        let mut receiver = response.receiver;
+
+        source.start().await.context("Failed to start source")?;
+
+        // Step 5: Collect events — we should see row 3 but NOT rows 1 or 2
+        let events = collect_events(&mut receiver, Duration::from_secs(15), 20).await;
+        let ids = extract_product_ids(&events);
+
+        log::info!("Received product IDs after resume: {ids:?}");
+
+        // Element IDs are formatted as "dbo.Products:N"
+        assert!(
+            !ids.iter().any(|id| id == "dbo.Products:1"),
+            "Row 1 should have been filtered out, but was received. IDs: {ids:?}"
+        );
+        assert!(
+            !ids.iter().any(|id| id == "dbo.Products:2"),
+            "Row 2 should have been filtered out (at skip_threshold), but was received. IDs: {ids:?}"
+        );
+
+        // Row 3 should arrive
+        assert!(
+            ids.iter().any(|id| id == "dbo.Products:3"),
+            "Row 3 should have arrived after resume. IDs: {ids:?}"
+        );
+
+        // Step 6: Insert row 4 and verify it arrives
+        execute_sql(
+            &mut client,
+            "INSERT INTO dbo.Products (ProductId, Name, Price) VALUES (4, 'Delta', 40.00);",
+        )
+        .await?;
+
+        let new_events = collect_events(&mut receiver, Duration::from_secs(15), 10).await;
+        let new_ids = extract_product_ids(&new_events);
+
+        log::info!("Received product IDs for new insert: {new_ids:?}");
+        assert!(
+            new_ids.iter().any(|id| id == "dbo.Products:4"),
+            "Row 4 should have been received. IDs: {new_ids:?}"
+        );
+
+        source.stop().await?;
+        mssql.cleanup().await;
+
+        Ok::<(), anyhow::Error>(())
+    })
+    .await;
+
+    match result {
+        Ok(inner) => inner?,
+        Err(_) => anyhow::bail!("Test timed out after 300 seconds"),
+    }
+
+    Ok(())
+}
+
+/// Verify that subscribe() returns PositionUnavailable when the requested
+/// position is before the CDC retention window.
+#[tokio::test]
+#[ignore]
+#[cfg(not(target_arch = "aarch64"))]
+async fn test_mssql_replay_position_unavailable() -> Result<()> {
+    let _ = env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info"))
+        .is_test(true)
+        .try_init();
+
+    let result = timeout(Duration::from_secs(300), async {
+        let mssql = setup_mssql()
+            .await
+            .context("Failed to start MSSQL container")?;
+        let db_config = prepare_database(mssql.config())
+            .await
+            .context("Failed to prepare database")?;
+
+        // Insert data so CDC has real LSNs (min_lsn > 0)
+        let mut client = db_config.connect().await?;
+        execute_sql(
+            &mut client,
+            "INSERT INTO dbo.Products (ProductId, Name, Price) VALUES (1, 'Test', 1.00);",
+        )
+        .await?;
+        wait_for_cdc_rows(&db_config, 1)
+            .await
+            .context("CDC did not capture rows")?;
+
+        // Verify min_lsn is non-zero
+        let min_lsn_row = {
+            let mut c = db_config.connect().await?;
+            let stream = c
+                .query(
+                    "SELECT sys.fn_cdc_get_min_lsn('dbo_Products') AS min_lsn",
+                    &[],
+                )
+                .await?;
+            let rows = stream.into_first_result().await?;
+            let lsn_bytes: &[u8] = rows[0]
+                .try_get(0)?
+                .ok_or_else(|| anyhow::anyhow!("min_lsn is NULL"))?;
+            Lsn::from_bytes(lsn_bytes)?
+        };
+        log::info!("min_lsn = {}", min_lsn_row.to_hex());
+        assert!(
+            min_lsn_row > Lsn::zero(),
+            "Expected non-zero min_lsn after inserting data"
+        );
+
+        // Try to subscribe with a position that's before min_lsn
+        let expired_pos = cdc_position(&Lsn::zero(), &Lsn::zero());
+
+        let source = make_source(&db_config, StartPosition::Beginning)?;
+        let ctx = make_context();
+        source.initialize(ctx).await;
+
+        let subscribe_result = source.subscribe(make_settings(Some(expired_pos))).await;
+
+        let err = match subscribe_result {
+            Err(e) => e,
+            Ok(_) => anyhow::bail!("subscribe should have failed with expired position"),
+        };
+
+        // Downcast to SourceError::PositionUnavailable
+        let source_err = err
+            .downcast_ref::<SourceError>()
+            .expect("Error should be SourceError");
+
+        match source_err {
+            SourceError::PositionUnavailable {
+                source_id,
+                earliest_available,
+                ..
+            } => {
+                assert_eq!(source_id, SOURCE_ID);
+                assert!(
+                    earliest_available.is_some(),
+                    "earliest_available should be provided"
+                );
+                // Verify the earliest_available position extracts to a valid LSN
+                let earliest = earliest_available.unwrap();
+                let earliest_lsn = position_to_seek_lsn(&earliest)?;
+                assert!(
+                    earliest_lsn >= min_lsn_row,
+                    "earliest_available LSN should be >= min_lsn"
+                );
+            }
+        }
+
+        log::info!("Got expected PositionUnavailable error");
+
+        mssql.cleanup().await;
+
+        Ok::<(), anyhow::Error>(())
+    })
+    .await;
+
+    match result {
+        Ok(inner) => inner?,
+        Err(_) => anyhow::bail!("Test timed out after 300 seconds"),
+    }
+
+    Ok(())
+}

--- a/core/src/in_memory_index/in_memory_result_index.rs
+++ b/core/src/in_memory_index/in_memory_result_index.rs
@@ -22,6 +22,7 @@ use std::{
 use crate::interface::{
     ResultIndex, ResultKey, ResultOwner, ResultSequence, ResultSequenceCounter,
 };
+use crate::position::SequencePosition;
 use async_trait::async_trait;
 use hashers::builtin::DefaultHasher;
 use ordered_float::OrderedFloat;
@@ -180,7 +181,7 @@ impl LazySortedSetStore for InMemoryResultIndex {
 impl ResultSequenceCounter for InMemoryResultIndex {
     async fn apply_sequence(
         &self,
-        sequence: u64,
+        sequence: SequencePosition,
         source_change_id: &str,
     ) -> Result<(), IndexError> {
         let mut data = self.sequence.write().await;

--- a/core/src/index_cache/cached_result_index.rs
+++ b/core/src/index_cache/cached_result_index.rs
@@ -164,7 +164,7 @@ impl LazySortedSetStore for CachedResultIndex {
 impl ResultSequenceCounter for CachedResultIndex {
     async fn apply_sequence(
         &self,
-        sequence: u64,
+        sequence: crate::position::SequencePosition,
         source_change_id: &str,
     ) -> Result<(), IndexError> {
         self.inner.apply_sequence(sequence, source_change_id).await

--- a/core/src/interface/result_index.rs
+++ b/core/src/interface/result_index.rs
@@ -65,14 +65,14 @@ pub trait LazySortedSetStore: Send + Sync {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ResultSequence {
-    pub sequence: u64,
+    pub sequence: crate::position::SequencePosition,
     pub source_change_id: Arc<str>,
 }
 
 impl Default for ResultSequence {
     fn default() -> Self {
         ResultSequence {
-            sequence: 0,
+            sequence: crate::position::SequencePosition::default(),
             source_change_id: Arc::from(""),
         }
     }
@@ -80,8 +80,11 @@ impl Default for ResultSequence {
 
 #[async_trait]
 pub trait ResultSequenceCounter: Send + Sync {
-    async fn apply_sequence(&self, sequence: u64, source_change_id: &str)
-        -> Result<(), IndexError>;
+    async fn apply_sequence(
+        &self,
+        sequence: crate::position::SequencePosition,
+        source_change_id: &str,
+    ) -> Result<(), IndexError>;
     async fn get_sequence(&self) -> Result<ResultSequence, IndexError>;
 }
 

--- a/core/src/position.rs
+++ b/core/src/position.rs
@@ -1,0 +1,399 @@
+// Copyright 2025 The Drasi Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Opaque position type for source replay and resume.
+
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use std::cmp::Ordering;
+use std::fmt;
+
+/// Error returned by [`SequencePosition::try_from_bytes`] when the input
+/// exceeds [`MAX_POSITION_BYTES`].
+#[derive(Debug, Clone)]
+pub struct SequencePositionError {
+    /// Length of the slice that was too large.
+    pub actual_len: usize,
+}
+
+impl fmt::Display for SequencePositionError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "SequencePosition: {} bytes exceeds maximum {MAX_POSITION_BYTES}",
+            self.actual_len,
+        )
+    }
+}
+
+impl std::error::Error for SequencePositionError {}
+
+/// Maximum bytes for a source position.
+///
+/// MSSQL: 20 (start_lsn + seqval), Postgres: 8 (WAL LSN), Kafka: 8.
+/// 24 bytes provides headroom for future sources.
+pub const MAX_POSITION_BYTES: usize = 24;
+
+/// Opaque, source-defined position marker for replay and resume.
+///
+/// Uses a fixed-size inline buffer — no heap allocation, [`Copy`]-able.
+/// Comparison is lexicographic over the active bytes `data[0..len]`.
+///
+/// # Source Encodings
+///
+/// - **Postgres**: 8 bytes (WAL LSN as big-endian u64)
+/// - **MSSQL**: 20 bytes (start_lsn ∥ seqval, each 10 bytes)
+///
+/// # Invariant
+///
+/// All positions emitted by a single source instance use the same byte length.
+/// Cross-source position comparison is undefined.
+#[derive(Clone, Copy)]
+pub struct SequencePosition {
+    data: [u8; MAX_POSITION_BYTES],
+    len: u8,
+}
+
+impl SequencePosition {
+    /// Create from a byte slice. Panics if `bytes.len() > MAX_POSITION_BYTES`.
+    ///
+    /// For untrusted input (storage, wire data), prefer [`try_from_bytes`](Self::try_from_bytes).
+    pub fn from_bytes(bytes: &[u8]) -> Self {
+        assert!(
+            bytes.len() <= MAX_POSITION_BYTES,
+            "SequencePosition: {} bytes exceeds maximum {}",
+            bytes.len(),
+            MAX_POSITION_BYTES,
+        );
+        let mut data = [0u8; MAX_POSITION_BYTES];
+        data[..bytes.len()].copy_from_slice(bytes);
+        Self {
+            data,
+            len: bytes.len() as u8,
+        }
+    }
+
+    /// Fallible version of [`from_bytes`](Self::from_bytes) for untrusted input.
+    ///
+    /// Returns `Err` if `bytes.len() > MAX_POSITION_BYTES`.
+    pub fn try_from_bytes(bytes: &[u8]) -> Result<Self, SequencePositionError> {
+        if bytes.len() > MAX_POSITION_BYTES {
+            return Err(SequencePositionError {
+                actual_len: bytes.len(),
+            });
+        }
+        let mut data = [0u8; MAX_POSITION_BYTES];
+        data[..bytes.len()].copy_from_slice(bytes);
+        Ok(Self {
+            data,
+            len: bytes.len() as u8,
+        })
+    }
+
+    /// Access the active bytes.
+    pub fn as_bytes(&self) -> &[u8] {
+        &self.data[..self.len as usize]
+    }
+
+    /// Create from a `u64` value (stored as 8 big-endian bytes).
+    pub fn from_u64(val: u64) -> Self {
+        Self::from_bytes(&val.to_be_bytes())
+    }
+
+    /// Try to extract as a `u64`. Returns `None` unless the position is exactly 8 bytes.
+    pub fn to_u64(&self) -> Option<u64> {
+        if self.len == 8 {
+            let arr: [u8; 8] = self.data[..8].try_into().expect("len is 8");
+            Some(u64::from_be_bytes(arr))
+        } else {
+            None
+        }
+    }
+
+    /// Length of the active position data.
+    pub fn len(&self) -> usize {
+        self.len as usize
+    }
+
+    /// Whether this position has zero-length data.
+    pub fn is_empty(&self) -> bool {
+        self.len == 0
+    }
+}
+
+impl Default for SequencePosition {
+    fn default() -> Self {
+        Self {
+            data: [0u8; MAX_POSITION_BYTES],
+            len: 0,
+        }
+    }
+}
+
+// -- Comparison (lexicographic on active bytes) --
+
+impl PartialEq for SequencePosition {
+    fn eq(&self, other: &Self) -> bool {
+        self.as_bytes() == other.as_bytes()
+    }
+}
+
+impl Eq for SequencePosition {}
+
+impl PartialOrd for SequencePosition {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for SequencePosition {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.as_bytes().cmp(other.as_bytes())
+    }
+}
+
+impl std::hash::Hash for SequencePosition {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.as_bytes().hash(state);
+    }
+}
+
+// -- Display / Debug --
+
+impl fmt::Display for SequencePosition {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        for byte in self.as_bytes() {
+            write!(f, "{byte:02x}")?;
+        }
+        Ok(())
+    }
+}
+
+impl fmt::Debug for SequencePosition {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "SequencePosition({self})")
+    }
+}
+
+// -- Serde (serializes only the active bytes as a byte array) --
+
+impl Serialize for SequencePosition {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_bytes(self.as_bytes())
+    }
+}
+
+impl<'de> Deserialize<'de> for SequencePosition {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        struct Visitor;
+        impl<'de> serde::de::Visitor<'de> for Visitor {
+            type Value = SequencePosition;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+                write!(
+                    formatter,
+                    "a byte array of at most {MAX_POSITION_BYTES} bytes",
+                )
+            }
+
+            fn visit_bytes<E: serde::de::Error>(self, v: &[u8]) -> Result<Self::Value, E> {
+                if v.len() > MAX_POSITION_BYTES {
+                    return Err(E::invalid_length(
+                        v.len(),
+                        &format!("at most {MAX_POSITION_BYTES} bytes").as_str(),
+                    ));
+                }
+                Ok(SequencePosition::from_bytes(v))
+            }
+
+            fn visit_byte_buf<E: serde::de::Error>(self, v: Vec<u8>) -> Result<Self::Value, E> {
+                self.visit_bytes(&v)
+            }
+
+            // Support sequence deserialization (JSON arrays)
+            fn visit_seq<A: serde::de::SeqAccess<'de>>(
+                self,
+                mut seq: A,
+            ) -> Result<Self::Value, A::Error> {
+                let mut bytes = Vec::with_capacity(MAX_POSITION_BYTES);
+                while let Some(byte) = seq.next_element::<u8>()? {
+                    bytes.push(byte);
+                }
+                if bytes.len() > MAX_POSITION_BYTES {
+                    return Err(serde::de::Error::invalid_length(
+                        bytes.len(),
+                        &format!("at most {MAX_POSITION_BYTES} bytes").as_str(),
+                    ));
+                }
+                Ok(SequencePosition::from_bytes(&bytes))
+            }
+        }
+        deserializer.deserialize_bytes(Visitor)
+    }
+}
+
+// -- Conversion helpers --
+
+impl From<u64> for SequencePosition {
+    fn from(val: u64) -> Self {
+        Self::from_u64(val)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_from_u64_round_trip() {
+        let pos = SequencePosition::from_u64(42);
+        assert_eq!(pos.to_u64(), Some(42));
+        assert_eq!(pos.len(), 8);
+    }
+
+    #[test]
+    fn test_from_u64_zero() {
+        let pos = SequencePosition::from_u64(0);
+        assert_eq!(pos.to_u64(), Some(0));
+    }
+
+    #[test]
+    fn test_from_u64_max() {
+        let pos = SequencePosition::from_u64(u64::MAX);
+        assert_eq!(pos.to_u64(), Some(u64::MAX));
+    }
+
+    #[test]
+    fn test_from_bytes_20() {
+        let bytes: Vec<u8> = (0..20).collect();
+        let pos = SequencePosition::from_bytes(&bytes);
+        assert_eq!(pos.as_bytes(), &bytes[..]);
+        assert_eq!(pos.len(), 20);
+        assert_eq!(pos.to_u64(), None); // not 8 bytes
+    }
+
+    #[test]
+    fn test_ordering_u64() {
+        let a = SequencePosition::from_u64(10);
+        let b = SequencePosition::from_u64(20);
+        assert!(a < b);
+    }
+
+    #[test]
+    fn test_ordering_same_length() {
+        let a = SequencePosition::from_bytes(&[0x00, 0x01]);
+        let b = SequencePosition::from_bytes(&[0x00, 0x02]);
+        assert!(a < b);
+    }
+
+    #[test]
+    fn test_ordering_different_length() {
+        // Lexicographic: shorter prefix is less
+        let a = SequencePosition::from_bytes(&[0x00, 0x01]);
+        let b = SequencePosition::from_bytes(&[0x00, 0x01, 0x00]);
+        assert!(a < b);
+    }
+
+    #[test]
+    fn test_equality() {
+        let a = SequencePosition::from_u64(42);
+        let b = SequencePosition::from_u64(42);
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn test_display_hex() {
+        let pos = SequencePosition::from_bytes(&[0xAB, 0xCD, 0xEF]);
+        assert_eq!(format!("{pos}"), "abcdef");
+    }
+
+    #[test]
+    fn test_debug() {
+        let pos = SequencePosition::from_u64(1);
+        let debug_str = format!("{pos:?}");
+        assert!(debug_str.starts_with("SequencePosition("));
+    }
+
+    #[test]
+    fn test_default_is_empty() {
+        let pos = SequencePosition::default();
+        assert!(pos.is_empty());
+        assert_eq!(pos.len(), 0);
+        assert_eq!(pos.as_bytes(), &[] as &[u8]);
+    }
+
+    #[test]
+    fn test_copy_semantics() {
+        let a = SequencePosition::from_u64(100);
+        let b = a; // Copy
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn test_serde_json_round_trip() {
+        let pos = SequencePosition::from_u64(42);
+        let json = serde_json::to_string(&pos).unwrap();
+        let deserialized: SequencePosition = serde_json::from_str(&json).unwrap();
+        assert_eq!(pos, deserialized);
+    }
+
+    #[test]
+    fn test_serde_json_20_bytes() {
+        let bytes: Vec<u8> = (0..20).collect();
+        let pos = SequencePosition::from_bytes(&bytes);
+        let json = serde_json::to_string(&pos).unwrap();
+        let deserialized: SequencePosition = serde_json::from_str(&json).unwrap();
+        assert_eq!(pos, deserialized);
+    }
+
+    #[test]
+    fn test_from_u64_trait() {
+        let pos: SequencePosition = 42u64.into();
+        assert_eq!(pos.to_u64(), Some(42));
+    }
+
+    #[test]
+    #[should_panic(expected = "exceeds maximum")]
+    fn test_from_bytes_too_large() {
+        SequencePosition::from_bytes(&[0u8; 25]);
+    }
+
+    #[test]
+    fn test_hash_consistency() {
+        use std::collections::HashSet;
+        let mut set = HashSet::new();
+        set.insert(SequencePosition::from_u64(42));
+        assert!(set.contains(&SequencePosition::from_u64(42)));
+        assert!(!set.contains(&SequencePosition::from_u64(43)));
+    }
+
+    #[test]
+    fn test_try_from_bytes_ok() {
+        let bytes: Vec<u8> = (0..20).collect();
+        let pos = SequencePosition::try_from_bytes(&bytes).unwrap();
+        assert_eq!(pos.as_bytes(), &bytes[..]);
+    }
+
+    #[test]
+    fn test_try_from_bytes_too_large() {
+        let err = SequencePosition::try_from_bytes(&[0u8; 25]).unwrap_err();
+        assert_eq!(err.actual_len, 25);
+        assert!(err.to_string().contains("25 bytes exceeds maximum"));
+    }
+
+    #[test]
+    fn test_try_from_bytes_at_max() {
+        let pos = SequencePosition::try_from_bytes(&[0xFFu8; MAX_POSITION_BYTES]).unwrap();
+        assert_eq!(pos.len(), MAX_POSITION_BYTES);
+    }
+}

--- a/lib/src/bootstrap/mod.rs
+++ b/lib/src/bootstrap/mod.rs
@@ -139,7 +139,7 @@ use crate::channels::BootstrapEventSender;
 #[derive(Debug, Clone, Default)]
 pub struct BootstrapResult {
     pub event_count: usize,
-    pub last_sequence: Option<u64>,
+    pub last_sequence: Option<crate::SequencePosition>,
     pub sequences_aligned: bool,
 }
 

--- a/lib/src/channels/events.rs
+++ b/lib/src/channels/events.rs
@@ -12,11 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::position::SequencePosition;
 use crate::profiling::ProfilingMetadata;
 use drasi_core::models::SourceChange;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
-use std::sync::atomic::AtomicU64;
 use std::sync::Arc;
 use tokio::sync::{broadcast, mpsc};
 
@@ -217,10 +217,10 @@ pub struct SourceEventWrapper {
     pub timestamp: chrono::DateTime<chrono::Utc>,
     /// Optional profiling metadata for performance tracking
     pub profiling: Option<ProfilingMetadata>,
-    /// Monotonic, replayable sequence number stamped by the source.
+    /// Monotonic, replayable sequence position stamped by the source.
     /// `None` for volatile sources that don't support replay.
     /// When present, must be strictly increasing per source.
-    pub sequence: Option<u64>,
+    pub sequence: Option<SequencePosition>,
 }
 
 impl SourceEventWrapper {
@@ -255,12 +255,12 @@ impl SourceEventWrapper {
         }
     }
 
-    /// Create a new SourceEventWrapper with a sequence number (and optional profiling)
+    /// Create a new SourceEventWrapper with a sequence position (and optional profiling)
     pub fn with_sequence(
         source_id: String,
         event: SourceEvent,
         timestamp: chrono::DateTime<chrono::Utc>,
-        sequence: u64,
+        sequence: SequencePosition,
         profiling: Option<ProfilingMetadata>,
     ) -> Self {
         Self {
@@ -281,7 +281,7 @@ impl SourceEventWrapper {
         SourceEvent,
         chrono::DateTime<chrono::Utc>,
         Option<ProfilingMetadata>,
-        Option<u64>,
+        Option<SequencePosition>,
     ) {
         (
             self.source_id,
@@ -306,7 +306,7 @@ impl SourceEventWrapper {
             SourceEvent,
             chrono::DateTime<chrono::Utc>,
             Option<ProfilingMetadata>,
-            Option<u64>,
+            Option<SequencePosition>,
         ),
         Arc<Self>,
     > {
@@ -351,10 +351,10 @@ pub struct SubscriptionResponse {
     pub bootstrap_receiver: Option<BootstrapEventReceiver>,
     /// Shared handle for the query to report its last durably-processed sequence position.
     /// Created by replay-capable sources when `request_position_handle` is true.
-    /// The query writes to this atomically after each commit; the source reads the
+    /// The query writes to this after each commit; the source reads the
     /// minimum across all subscribers to advance its upstream cursor.
-    /// Sources should initialize this to `u64::MAX` (meaning "no position confirmed yet").
-    pub position_handle: Option<Arc<AtomicU64>>,
+    /// Sources should initialize this to `None` (meaning "no position confirmed yet").
+    pub position_handle: Option<Arc<std::sync::Mutex<Option<SequencePosition>>>>,
 }
 
 /// Subscription response from Query to Reaction
@@ -676,14 +676,14 @@ mod tests {
             "test-source".to_string(),
             SourceEvent::Change(change),
             chrono::Utc::now(),
-            42,
+            SequencePosition::from_u64(42),
             None,
         );
-        assert_eq!(wrapper.sequence, Some(42));
+        assert_eq!(wrapper.sequence, Some(SequencePosition::from_u64(42)));
         assert!(wrapper.profiling.is_none());
 
         let (_source_id, _event, _timestamp, _profiling, sequence) = wrapper.into_parts();
-        assert_eq!(sequence, Some(42));
+        assert_eq!(sequence, Some(SequencePosition::from_u64(42)));
     }
 
     #[test]
@@ -699,16 +699,18 @@ mod tests {
 
     #[test]
     fn test_subscription_response_with_position_handle() {
-        use std::sync::atomic::{AtomicU64, Ordering};
-        use std::sync::Arc;
+        use std::sync::{Arc, Mutex};
 
-        let handle = Arc::new(AtomicU64::new(u64::MAX));
-        assert_eq!(handle.load(Ordering::Relaxed), u64::MAX);
+        let handle = Arc::new(Mutex::new(None::<SequencePosition>));
+        assert!(handle.lock().unwrap().is_none());
 
         // Verify the handle can be cloned and read (simulates source reading query's position)
         let handle_clone = handle.clone();
-        handle.store(500, Ordering::Relaxed);
-        assert_eq!(handle_clone.load(Ordering::Relaxed), 500);
+        *handle.lock().unwrap() = Some(SequencePosition::from_u64(500));
+        assert_eq!(
+            *handle_clone.lock().unwrap(),
+            Some(SequencePosition::from_u64(500))
+        );
     }
 
     #[test]
@@ -720,10 +722,10 @@ mod tests {
             query_id: "test-query".to_string(),
             nodes: HashSet::new(),
             relations: HashSet::new(),
-            resume_from: Some(500),
+            resume_from: Some(SequencePosition::from_u64(500)),
             request_position_handle: true,
         };
-        assert_eq!(settings.resume_from, Some(500));
+        assert_eq!(settings.resume_from, Some(SequencePosition::from_u64(500)));
         assert!(settings.request_position_handle);
     }
 }

--- a/lib/src/config/schema.rs
+++ b/lib/src/config/schema.rs
@@ -163,8 +163,8 @@ pub struct SourceSubscriptionSettings {
     pub relations: HashSet<String>,
     /// If set, the subscribing query requests events replayed from this sequence position.
     /// Only meaningful when the source returns `supports_replay() == true`.
-    pub resume_from: Option<u64>,
-    /// If true, the query requests a shared `Arc<AtomicU64>` position handle in the
+    pub resume_from: Option<crate::position::SequencePosition>,
+    /// If true, the query requests a shared position handle in the
     /// `SubscriptionResponse` for reporting its durably-processed position back to the source.
     pub request_position_handle: bool,
 }

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -34,6 +34,9 @@
 /// Component dependency graph — the single source of truth for configuration
 pub mod component_graph;
 
+/// Opaque position type for source replay and resume
+pub mod position;
+
 /// Fluent builders for DrasiLib and components
 pub mod builder;
 
@@ -174,6 +177,9 @@ pub use sources::Source;
 
 /// Structured error type for source operations (e.g., replay position unavailable)
 pub use sources::SourceError;
+
+/// Opaque position type for source replay and resume
+pub use position::SequencePosition;
 
 /// Reaction traits for implementing reaction plugins
 pub use reactions::Reaction;

--- a/lib/src/position.rs
+++ b/lib/src/position.rs
@@ -1,4 +1,4 @@
-// Copyright 2024 The Drasi Authors.
+// Copyright 2025 The Drasi Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,12 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub mod evaluation;
-pub mod in_memory_index;
-pub mod index_cache;
-pub mod interface;
-pub mod middleware;
-pub mod models;
-pub mod path_solver;
-pub mod position;
-pub mod query;
+//! Opaque position type for source replay and resume.
+//!
+//! Re-exports [`drasi_core::position::SequencePosition`] for convenience.
+
+pub use drasi_core::position::{SequencePosition, SequencePositionError, MAX_POSITION_BYTES};

--- a/lib/src/sources/base.rs
+++ b/lib/src/sources/base.rs
@@ -32,8 +32,8 @@
 use anyhow::Result;
 use log::{debug, error, info, warn};
 use std::collections::HashMap;
-use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
+use std::sync::Mutex;
 use tokio::sync::RwLock;
 use tracing::Instrument;
 
@@ -42,6 +42,7 @@ use crate::channels::*;
 use crate::component_graph::ComponentStatusHandle;
 use crate::context::SourceRuntimeContext;
 use crate::identity::IdentityProvider;
+use crate::position::SequencePosition;
 use crate::profiling;
 use crate::state_store::StateStoreProvider;
 use drasi_core::models::SourceChange;
@@ -168,13 +169,13 @@ pub struct SourceBase {
     identity_provider: Arc<RwLock<Option<Arc<dyn IdentityProvider>>>>,
     /// Per-query position handles for replay-capable subscribers.
     ///
-    /// Keyed by `query_id`. Values are the same `Arc<AtomicU64>` returned in
-    /// `SubscriptionResponse::position_handle`. The query writes its last
+    /// Keyed by `query_id`. Values are the same `Arc<Mutex<Option<SequencePosition>>>`
+    /// returned in `SubscriptionResponse::position_handle`. The query writes its last
     /// durably-processed sequence; the source reads `compute_confirmed_position()`
-    /// to advance its upstream cursor. Initial value is `u64::MAX`
+    /// to advance its upstream cursor. Initial value is `None`
     /// ("no position confirmed yet"). Only populated when
     /// `request_position_handle == true`.
-    position_handles: Arc<RwLock<HashMap<String, Arc<AtomicU64>>>>,
+    position_handles: Arc<RwLock<HashMap<String, Arc<Mutex<Option<SequencePosition>>>>>>,
 }
 
 impl SourceBase {
@@ -290,19 +291,22 @@ impl SourceBase {
         *self.identity_provider.write().await = Some(provider);
     }
 
-    /// Create and register a position handle for `query_id`, initialized to `u64::MAX`.
+    /// Create and register a position handle for `query_id`, initialized to `None`.
     ///
     /// Returns the shared handle; the same `Arc` is placed in
     /// `SubscriptionResponse::position_handle` so the query and the source share
-    /// one atomic. If a handle already exists for `query_id` (re-subscribe after
-    /// transient disconnect), the existing handle is returned to preserve any
-    /// position the query had previously reported.
-    pub async fn create_position_handle(&self, query_id: &str) -> Arc<AtomicU64> {
+    /// one mutex-guarded position. If a handle already exists for `query_id`
+    /// (re-subscribe after transient disconnect), the existing handle is returned
+    /// to preserve any position the query had previously reported.
+    pub async fn create_position_handle(
+        &self,
+        query_id: &str,
+    ) -> Arc<Mutex<Option<SequencePosition>>> {
         let mut handles = self.position_handles.write().await;
         if let Some(existing) = handles.get(query_id) {
             return existing.clone();
         }
-        let handle = Arc::new(AtomicU64::new(u64::MAX));
+        let handle = Arc::new(Mutex::new(None));
         handles.insert(query_id.to_string(), handle.clone());
         handle
     }
@@ -320,24 +324,40 @@ impl SourceBase {
     /// Compute the minimum confirmed position across all live subscribers.
     ///
     /// Returns `None` if no handles are registered, or if every registered
-    /// handle is still `u64::MAX` (no subscriber has confirmed a position yet —
+    /// handle is still `None` (no subscriber has confirmed a position yet —
     /// typically because they are still bootstrapping). Otherwise returns the
-    /// minimum non-`u64::MAX` value, suitable for advancing the source's
+    /// minimum confirmed position, suitable for advancing the source's
     /// upstream cursor (Postgres `flush_lsn`, Kafka commit, transient WAL prune
     /// threshold).
     ///
     /// Piggy-backs `cleanup_stale_handles()` so dropped subscribers do not pin
     /// the watermark indefinitely.
-    pub async fn compute_confirmed_position(&self) -> Option<u64> {
+    pub async fn compute_confirmed_position(&self) -> Option<SequencePosition> {
         self.cleanup_stale_handles().await;
         let handles = self.position_handles.read().await;
-        let mut min: Option<u64> = None;
+        let mut min: Option<SequencePosition> = None;
         for handle in handles.values() {
-            let v = handle.load(Ordering::Relaxed);
-            if v == u64::MAX {
-                continue;
+            let guard = match handle.lock() {
+                Ok(guard) => guard,
+                Err(poisoned) => {
+                    log::warn!(
+                        "position handle mutex poisoned while computing confirmed position; recovering inner value"
+                    );
+                    poisoned.into_inner()
+                }
+            };
+            if let Some(pos) = guard.as_ref() {
+                min = Some(match min {
+                    None => *pos,
+                    Some(m) => {
+                        if *pos < m {
+                            *pos
+                        } else {
+                            m
+                        }
+                    }
+                });
             }
-            min = Some(min.map_or(v, |m| m.min(v)));
         }
         min
     }
@@ -921,12 +941,13 @@ mod tests {
         BootstrapContext, BootstrapProvider, BootstrapRequest, BootstrapResult,
     };
     use crate::channels::BootstrapEventSender;
+    use crate::SequencePosition;
     use async_trait::async_trait;
 
     fn make_settings(
         query_id: &str,
         enable_bootstrap: bool,
-        resume_from: Option<u64>,
+        resume_from: Option<SequencePosition>,
         request_position_handle: bool,
     ) -> crate::config::SourceSubscriptionSettings {
         use std::collections::HashSet;
@@ -965,29 +986,32 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_create_position_handle_initializes_to_u64_max() {
+    async fn test_create_position_handle_initializes_to_none() {
         let base = SourceBase::new(SourceBaseParams::new("ph-init")).unwrap();
         let handle = base.create_position_handle("q1").await;
-        assert_eq!(handle.load(Ordering::Relaxed), u64::MAX);
+        assert!(handle.lock().unwrap().is_none());
     }
 
     #[tokio::test]
     async fn test_create_position_handle_idempotent_for_same_query() {
         let base = SourceBase::new(SourceBaseParams::new("ph-idem")).unwrap();
         let h1 = base.create_position_handle("q1").await;
-        h1.store(123, Ordering::Relaxed);
+        *h1.lock().unwrap() = Some(SequencePosition::from_u64(123));
         let h2 = base.create_position_handle("q1").await;
         // Same Arc — preserves the previously reported position.
         assert!(Arc::ptr_eq(&h1, &h2));
-        assert_eq!(h2.load(Ordering::Relaxed), 123);
+        assert_eq!(*h2.lock().unwrap(), Some(SequencePosition::from_u64(123)));
     }
 
     #[tokio::test]
     async fn test_remove_position_handle_drops_entry() {
         let base = SourceBase::new(SourceBaseParams::new("ph-rm")).unwrap();
         let handle = base.create_position_handle("q1").await;
-        handle.store(42, Ordering::Relaxed);
-        assert_eq!(base.compute_confirmed_position().await, Some(42));
+        *handle.lock().unwrap() = Some(SequencePosition::from_u64(42));
+        assert_eq!(
+            base.compute_confirmed_position().await,
+            Some(SequencePosition::from_u64(42))
+        );
         base.remove_position_handle("q1").await;
         assert_eq!(base.compute_confirmed_position().await, None);
     }
@@ -1007,22 +1031,25 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_compute_confirmed_position_returns_none_when_all_max() {
-        let base = SourceBase::new(SourceBaseParams::new("ph-all-max")).unwrap();
+    async fn test_compute_confirmed_position_returns_none_when_all_unset() {
+        let base = SourceBase::new(SourceBaseParams::new("ph-all-none")).unwrap();
         let _h1 = base.create_position_handle("q1").await;
         let _h2 = base.create_position_handle("q2").await;
         assert_eq!(base.compute_confirmed_position().await, None);
     }
 
     #[tokio::test]
-    async fn test_compute_confirmed_position_filters_max_returns_min() {
+    async fn test_compute_confirmed_position_filters_none_returns_min() {
         let base = SourceBase::new(SourceBaseParams::new("ph-min")).unwrap();
         let h1 = base.create_position_handle("q1").await;
-        let _h2 = base.create_position_handle("q2").await; // stays u64::MAX
+        let _h2 = base.create_position_handle("q2").await; // stays None
         let h3 = base.create_position_handle("q3").await;
-        h1.store(100, Ordering::Relaxed);
-        h3.store(50, Ordering::Relaxed);
-        assert_eq!(base.compute_confirmed_position().await, Some(50));
+        *h1.lock().unwrap() = Some(SequencePosition::from_u64(100));
+        *h3.lock().unwrap() = Some(SequencePosition::from_u64(50));
+        assert_eq!(
+            base.compute_confirmed_position().await,
+            Some(SequencePosition::from_u64(50))
+        );
     }
 
     #[tokio::test]
@@ -1030,8 +1057,11 @@ mod tests {
         let base = SourceBase::new(SourceBaseParams::new("ph-single")).unwrap();
         let h1 = base.create_position_handle("q1").await;
         let _h2 = base.create_position_handle("q2").await;
-        h1.store(7, Ordering::Relaxed);
-        assert_eq!(base.compute_confirmed_position().await, Some(7));
+        *h1.lock().unwrap() = Some(SequencePosition::from_u64(7));
+        assert_eq!(
+            base.compute_confirmed_position().await,
+            Some(SequencePosition::from_u64(7))
+        );
     }
 
     #[tokio::test]
@@ -1039,7 +1069,7 @@ mod tests {
         let base = SourceBase::new(SourceBaseParams::new("ph-stale")).unwrap();
         {
             let handle = base.create_position_handle("q1").await;
-            handle.store(99, Ordering::Relaxed);
+            *handle.lock().unwrap() = Some(SequencePosition::from_u64(99));
             // handle (the external clone) drops here.
         }
         base.cleanup_stale_handles().await;
@@ -1050,10 +1080,13 @@ mod tests {
     async fn test_cleanup_stale_handles_keeps_held_arc() {
         let base = SourceBase::new(SourceBaseParams::new("ph-held")).unwrap();
         let handle = base.create_position_handle("q1").await;
-        handle.store(11, Ordering::Relaxed);
+        *handle.lock().unwrap() = Some(SequencePosition::from_u64(11));
         base.cleanup_stale_handles().await;
         // External clone still alive, entry retained.
-        assert_eq!(base.compute_confirmed_position().await, Some(11));
+        assert_eq!(
+            base.compute_confirmed_position().await,
+            Some(SequencePosition::from_u64(11))
+        );
         // Keep `handle` alive past the assertion.
         drop(handle);
     }
@@ -1066,9 +1099,9 @@ mod tests {
             .await
             .unwrap();
         let handle = response.position_handle.expect("expected handle");
-        assert_eq!(handle.load(Ordering::Relaxed), u64::MAX);
+        assert!(handle.lock().unwrap().is_none());
         // Internal map should also have the entry (so min-watermark sees it).
-        assert_eq!(base.compute_confirmed_position().await, None); // u64::MAX → None
+        assert_eq!(base.compute_confirmed_position().await, None); // None → None
     }
 
     #[tokio::test]
@@ -1093,15 +1126,21 @@ mod tests {
             .await
             .unwrap();
         let handle = response.position_handle.unwrap();
-        handle.store(42, Ordering::Relaxed);
-        assert_eq!(base.compute_confirmed_position().await, Some(42));
+        *handle.lock().unwrap() = Some(SequencePosition::from_u64(42));
+        assert_eq!(
+            base.compute_confirmed_position().await,
+            Some(SequencePosition::from_u64(42))
+        );
     }
 
     #[tokio::test]
     async fn test_subscribe_with_resume_from_skips_bootstrap() {
         let base = make_base_with_bootstrap("sub-resume");
         let response = base
-            .subscribe_with_bootstrap(&make_settings("q1", true, Some(100), false), "test")
+            .subscribe_with_bootstrap(
+                &make_settings("q1", true, Some(SequencePosition::from_u64(100)), false),
+                "test",
+            )
             .await
             .unwrap();
         assert!(
@@ -1114,7 +1153,10 @@ mod tests {
     async fn test_subscribe_resume_without_bootstrap_still_none() {
         let base = make_base_with_bootstrap("sub-resume-no-bs");
         let response = base
-            .subscribe_with_bootstrap(&make_settings("q1", false, Some(100), false), "test")
+            .subscribe_with_bootstrap(
+                &make_settings("q1", false, Some(SequencePosition::from_u64(100)), false),
+                "test",
+            )
             .await
             .unwrap();
         assert!(response.bootstrap_receiver.is_none());

--- a/lib/src/sources/tests.rs
+++ b/lib/src/sources/tests.rs
@@ -363,18 +363,25 @@ mod contract_tests {
     #[test]
     fn test_source_error_position_unavailable_display() {
         use crate::sources::SourceError;
+        use crate::SequencePosition;
 
         let err = SourceError::PositionUnavailable {
             source_id: "postgres-1".to_string(),
-            requested: 1000,
-            earliest_available: Some(5000),
+            requested: SequencePosition::from_u64(1000),
+            earliest_available: Some(SequencePosition::from_u64(5000)),
         };
 
-        // Verify display formatting
+        // Verify display formatting includes source id and both positions
         let msg = format!("{err}");
         assert!(msg.contains("postgres-1"));
-        assert!(msg.contains("1000"));
-        assert!(msg.contains("5000"));
+        assert!(
+            msg.contains(&format!("{}", SequencePosition::from_u64(1000))),
+            "error message should contain requested position"
+        );
+        assert!(
+            msg.contains(&format!("{}", SequencePosition::from_u64(5000))),
+            "error message should contain earliest available position"
+        );
 
         // Verify anyhow round-trip: SourceError → anyhow::Error → downcast
         let anyhow_err: anyhow::Error = err.into();
@@ -387,8 +394,8 @@ mod contract_tests {
                 earliest_available,
             } => {
                 assert_eq!(source_id, "postgres-1");
-                assert_eq!(*requested, 1000);
-                assert_eq!(*earliest_available, Some(5000));
+                assert_eq!(*requested, SequencePosition::from_u64(1000));
+                assert_eq!(*earliest_available, Some(SequencePosition::from_u64(5000)));
             }
         }
     }
@@ -396,10 +403,11 @@ mod contract_tests {
     #[test]
     fn test_source_error_position_unavailable_no_earliest() {
         use crate::sources::SourceError;
+        use crate::SequencePosition;
 
         let err = SourceError::PositionUnavailable {
             source_id: "http-wal".to_string(),
-            requested: 42,
+            requested: SequencePosition::from_u64(42),
             earliest_available: None,
         };
 

--- a/lib/src/sources/traits.rs
+++ b/lib/src/sources/traits.rs
@@ -61,8 +61,8 @@ pub enum SourceError {
     #[error("Source '{source_id}' cannot resume from position {requested}: position unavailable (earliest available: {earliest_available:?})")]
     PositionUnavailable {
         source_id: String,
-        requested: u64,
-        earliest_available: Option<u64>,
+        requested: crate::position::SequencePosition,
+        earliest_available: Option<crate::position::SequencePosition>,
     },
 }
 

--- a/shared-tests/src/sequence_counter.rs
+++ b/shared-tests/src/sequence_counter.rs
@@ -15,13 +15,14 @@
 use std::sync::Arc;
 
 use drasi_core::interface::{ResultSequence, ResultSequenceCounter};
+use drasi_core::position::SequencePosition;
 
 pub async fn sequence_counter(subject: &dyn ResultSequenceCounter) {
     let result = subject.get_sequence().await.expect("get_sequence failed");
     assert_eq!(result, ResultSequence::default());
 
     subject
-        .apply_sequence(2, "foo")
+        .apply_sequence(SequencePosition::from_u64(2), "foo")
         .await
         .expect("apply_sequence failed");
 
@@ -29,7 +30,7 @@ pub async fn sequence_counter(subject: &dyn ResultSequenceCounter) {
     assert_eq!(
         result,
         ResultSequence {
-            sequence: 2,
+            sequence: SequencePosition::from_u64(2),
             source_change_id: Arc::from("foo"),
         }
     );


### PR DESCRIPTION
## Summary

Implements [#379](https://github.com/drasi-project/drasi-core/issues/379) — MSSQL Source Replay Support. This PR adds checkpoint-based replay to the MSSQL CDC source so it can resume from a previously confirmed position after restart, and widens the framework's sequence type to support it.

## Problem

MSSQL CDC positions require **20 bytes** (10-byte `start_lsn` + 10-byte `seqval`) to uniquely and stably identify a row in the CDC stream. The framework's sequence type was `u64` (8 bytes), making it impossible to faithfully represent MSSQL positions without lossy encoding.

---

## Framework Widening: `SequencePosition` (Commit 1)

### Key Decisions

| Decision | Rationale |
|----------|-----------|
| **Opaque type over u64** | Any encoding of 20 bytes into 8 bytes is lossy. Truncation loses ordering guarantees; hashing loses ordering entirely. An opaque byte buffer is the only lossless option. |
| **Fixed-size inline buffer `[u8; 24]`** | Avoids heap allocation. 24 bytes covers MSSQL (20), Postgres (8), and leaves headroom for future sources. The type is `Copy`, so it works in atomics-free contexts. |
| **Lexicographic `Ord`** | Big-endian byte comparison preserves the natural ordering of LSN-based positions without source-specific comparators. |
| **`Arc<Mutex<Option<SequencePosition>>>` handles** | Replaces `Arc<AtomicU64>` with sentinel `u64::MAX`. `Option` makes "no position yet" explicit rather than relying on a magic sentinel value. `Mutex` is acceptable since position updates are infrequent (once per CDC poll batch). |
| **Lives in `core`, re-exported from `lib`** | Both crates need the type, and `core` cannot depend on `lib`. Placing it in `core` with a re-export avoids circular dependencies. |

### What Changed
- New `core/src/position.rs` with 16 unit tests
- Updated `ResultSequence`, `SourceEventWrapper`, `SubscriptionResponse`, `SourceError`, `BootstrapResult`
- Updated RocksDB (binary storage) and Garnet (hex-encoded) backends
- Updated shared test utilities

### What Did NOT Change
- `BootstrapEvent.sequence: u64` and `BootstrapContext::next_sequence() -> u64` — bootstrap uses monotonic counters, not source positions
- FFI types (`FfiBootstrapEvent`, `FfiSourceEvent`) — no sequence field in the FFI boundary

---

## MSSQL Replay Implementation (Commit 2)

### Key Decisions

| Decision | Rationale |
|----------|-----------|
| **20-byte position = `start_lsn \|\| seqval`** | Concatenating both 10-byte values produces a strictly increasing, lexicographically comparable position. Using `start_lsn` alone is insufficient — multiple rows in the same transaction share the same `start_lsn` but have different `seqval`. |
| **Resume via seek + skip_threshold** | On resume, extract `start_lsn` from the position as the CDC query's `from_lsn`, then filter individual rows where `position <= skip_threshold`. This handles the case where multiple rows share the same `start_lsn` but only some were already seen. |
| **`sys.fn_cdc_increment_lsn` for boundary advancement** | CDC range queries are inclusive on both ends `[from_lsn, to_lsn]`. Without incrementing, the next poll would re-fetch the last row of the previous batch. The SQL Server built-in function handles LSN arithmetic correctly. |
| **Strict `>` comparison for `from_lsn` vs `max_lsn`** | Changed from `>=` to `>` because when `from_lsn == max_lsn` (e.g., resuming into a transaction that is also the latest), there are valid rows to process — the skip_threshold handles filtering. |

### Integration Tests (require Docker SQL Server)

| Test | What it verifies |
|------|-----------------|
| `test_mssql_replay_events_carry_sequence_positions` | Each CDC event carries a unique, strictly-increasing `SequencePosition` |
| `test_mssql_replay_resume_filters_already_seen` | Resume from row 2's position skips rows 1–2 and only delivers row 3+ |
| `test_mssql_replay_position_unavailable` | `PositionUnavailable` error when resume position precedes CDC retention window |

Tests use `testcontainers` to spin up `mcr.microsoft.com/mssql/server:2022-latest` and are marked `#[ignore]` so they only run when explicitly requested with `--ignored`.

---

## Testing

- All existing unit tests pass (1,448+ across core, lib, rocksdb, mssql)
- All 3 new integration tests pass against real SQL Server on Docker
- `cargo clippy --all-targets --all-features` — no new warnings
- `cargo fmt` applied
